### PR TITLE
Update cAdvisor and base image versions in Dockerfile and build.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @christian-vdz
+.github/* @raffoul

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,5 +25,5 @@ Even better: You could submit a pull request with a fix / new feature!
    developers, or if you do not have permission to do that, you may request
    the second reviewer to merge it for you.
 
-[github]: https://github.com/christian-vdz/hassio-cadvisor-addon/issues
-[prs]: https://github.com/christian-vdz/hassio-cadvisor-addon/pulls
+[github]: https://github.com/raffoul/hassio-cadvisor-addon/issues
+[prs]: https://github.com/raffoul/hassio-cadvisor-addon/pulls

--- a/cadvisor/Dockerfile
+++ b/cadvisor/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/cadvisor/cadvisor:v0.47.2 as cadvisor
-FROM ghcr.io/hassio-addons/base:14.3.1
+FROM ghcr.io/google/cadvisor:v0.53.0 AS cadvisor
+FROM ghcr.io/hassio-addons/base:18.1.1
 
 RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
@@ -18,6 +18,7 @@ COPY rootfs /
 ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
+ARG BUILD_VERSION
 ARG BUILD_NAME
 ARG BUILD_REF
 ARG BUILD_REPOSITORY
@@ -29,13 +30,13 @@ LABEL \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
     io.hass.version=${BUILD_VERSION} \
-    maintainer="christian-vdz (https://github.com/christian-vdz)" \
+    maintainer="christian-vdz (https://github.com/raffoul)" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
     org.opencontainers.image.vendor="Cadvisor Hassio add-on" \
-    org.opencontainers.image.authors="christian-vdz (https://github.com/christian-vdz)" \
+    org.opencontainers.image.authors="raffoul (https://github.com/raffoul)" \
     org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.url="https://github.com/christian-vdz" \
+    org.opencontainers.image.url="https://github.com/raffoul" \
     org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
     org.opencontainers.image.created=${BUILD_DATE} \

--- a/cadvisor/build.yaml
+++ b/cadvisor/build.yaml
@@ -1,5 +1,5 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:14.3.1
-  amd64: ghcr.io/hassio-addons/base:14.3.1
-  armv7: ghcr.io/hassio-addons/base:14.3.1
+  aarch64: ghcr.io/hassio-addons/base:18.1.1
+  amd64: ghcr.io/hassio-addons/base:18.1.1
+  armv7: ghcr.io/hassio-addons/base:18.1.1


### PR DESCRIPTION
## Update cAdvisor and base image versions in Dockerfile and build.yaml

### Proposed Changes

Update the cAdvisor version to the latest stable release in the Dockerfile and build.yaml.
Update the Home Assistant add-on base image version to the latest stable in both files.
Ensure compatibility with the latest Home Assistant OS and Supervisor.
Fix Dockerfile warnings (variable definition, FROM/AS casing).
These changes ensure the add-on uses the most recent, secure, and supported dependencies, improving stability and maintainability.
